### PR TITLE
Took off slashes, made some changes to "action" and "install" TBC. in…

### DIFF
--- a/docs/ci-integrations/github/actions/action-installer.md
+++ b/docs/ci-integrations/github/actions/action-installer.md
@@ -1,21 +1,21 @@
 ---
 title: Installer
 ---
-# Scribe GitHub actions - `installer`
-Scribe offers GitHub actions for embedding evidence collecting and validated integrity of your supply chain. \
+# Scribe GitHub Actions - `installer`
+Scribe offers GitHub Actions for embedding evidence collecting and validated integrity of your supply chain. 
 
-`installer` is used to install Scribe tools on your workflow. \
+Use `installer` to install Scribe tools in your workflow.
 
-Further documentation [Github integration](https://scribe-security.netlify.app/docs/ci-integrations/github/)
+For Further documentation [Github integration](https://scribe-security.netlify.app/docs/ci-integrations/github/)
 
-## Other actions
+## Other Actions
 * [bom - action](https://github.com/scribe-security/action-bom/README.md)
 * [verify - action](https://github.com/scribe-security/action-verify/README.md)
 * [integrity report - action](https://github.com/scribe-security/action-report/README.md)
 * [installer - action](https://github.com/scribe-security/action-installer/README.md)
 
-## Tool installer action
-You can use the `installer` action to install any scribe tool in to your workflow allowing full access to all the CLI options in your workflows. \
+## Tool installer Action
+You can use the `installer` Action to install any scribe tool in to your workflow allowing full access to all the CLI options in your workflows. 
 
 Install the tool locally if you want to:
 - Generate/verify evidence (SBOMS) from docker daemon.


### PR DESCRIPTION
… workflow, not on.

1. Actions as part of GitHub Actions should be capitalized. 
2. The other uses of  "action" need to be decided, to be continued.
3. I assume installer is used to install "in" workflow.